### PR TITLE
Fixed CleanUp

### DIFF
--- a/MagicaVoxel_Importer.py
+++ b/MagicaVoxel_Importer.py
@@ -328,6 +328,10 @@ class VoxelObject:
         
         # Cleanup Mesh
         if cleanup:
+            bpy.ops.object.select_all(action='DESELECT')
+            for obj in objects:
+                obj.select_set(True) # Select all objects that were generated.
+            bpy.ops.object.join()
             bpy.ops.object.editmode_toggle()
             bpy.ops.mesh.select_all(action='SELECT')
             bpy.ops.mesh.remove_doubles()


### PR DESCRIPTION
Hi there, this is my first time doing a pull request, and i don't even know if the creator still visits this repository anyway.
The clean up in main is faulty, it tries to remove doubles but it can't since every box is an object and merge by distance doesn't merge vertices from different objects. So i first selected the generated objects and then joined them. This way now it actually merge vertices.

It's a really simple fix but reaaaaally needed.

Maybe i'll try to fix the problem where import just crashes Blender, it looks like it has to do with the size of something...
(don't really count on it, i'm new with coding stuff in blender and have 0 idea of how .vox files are formated)